### PR TITLE
Fix various issues.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,35 @@ var RSVP = require('rsvp');
 var exit;
 var handlers = [];
 var lastTime;
+var isExiting = false;
 
-process.on('beforeExit', function () {
+process.on('beforeExit', function (code) {
   if (handlers.length === 0) { return; }
 
-  return module.exports._flush();
+  var own = lastTime = module.exports._flush(lastTime, code)
+    .finally(function () {
+      // if an onExit handler has called process.exit, do not disturb
+      // `lastTime`.
+      //
+      // Otherwise, clear `lastTime` so that we know to synchronously call the
+      // real `process.exit` with the given exit code, when our captured
+      // `process.exit` is called during a `process.on('exit')` handler
+      //
+      // This is impossible to reason about, don't feel bad.  Just look at
+      // test-natural-exit-subprocess-error.js
+      if (own === lastTime) {
+        lastTime = undefined;
+      }
+    });
 });
+
+// This exists only for testing
+module.exports._reset = function () {
+  module.exports.releaseExit();
+  handlers = [];
+  lastTime = undefined;
+  isExiting = false;
+}
 
 /*
  * To allow cooperative async exit handlers, we unfortunately must hijack
@@ -71,6 +94,7 @@ module.exports.captureExit = function() {
 
 module.exports._handlers = handlers;
 module.exports._flush = function(lastTime, code) {
+  isExiting = true;
   var work = handlers.splice(0, handlers.length);
 
   return RSVP.Promise.resolve(lastTime).

--- a/index.js
+++ b/index.js
@@ -109,6 +109,9 @@ module.exports.onExit = function(cb) {
   if (!exit) {
     throw new Error('Cannot install handler when exit is not captured.  Call `captureExit()` first');
   }
+  if (isExiting) {
+    throw new Error('Cannot install handler while `onExit` handlers are running.');
+  }
   var index = handlers.indexOf(cb);
 
   if (index > -1) { return; }

--- a/test-natural-exit-subprocess-error-exit-from-captures-on-exit.js
+++ b/test-natural-exit-subprocess-error-exit-from-captures-on-exit.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var capture = require('./');
+capture.captureExit();
+
+capture.onExit(function () {
+  console.log('onExit');
+  process.exit(1);
+});
+
+capture.onExit(function () {
+  console.log('onExit2');
+  process.exit(2);
+});
+
+process.on('exit', function () {
+  console.log('exit');
+});
+

--- a/test-natural-exit-subprocess-error.js
+++ b/test-natural-exit-subprocess-error.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var capture = require('./');
+capture.captureExit();
+
+capture.onExit(function () {
+  console.log('onExit');
+});
+
+process.on('exit', function () {
+  console.log('exit');
+  process.exit(1);
+});
+

--- a/test-natural-exit-subprocess.js
+++ b/test-natural-exit-subprocess.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var capture = require('./');
+capture.captureExit();
+
+capture.onExit(function () {
+  console.log('onExit');
+})
+
+process.on('exit', function () {
+  console.log('exit');
+});

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ var RSVP = require('rsvp');
 
 var originalExit = process.exit; // keep this around for good measure.
 var exit = require('./');
+var childProcess = require('child_process');
 
 describe('capture-exit', function() {
   beforeEach(function() {
@@ -203,6 +204,29 @@ describe('capture-exit', function() {
         expect(didExitBar).to.equal(1);
       });
     });
+  });
+});
+
+describe('natural exit', function() {
+  it('runs handlers on a natural exit', function() {
+    var output = childProcess.execSync('node test-natural-exit-subprocess.js');
+    expect(output+'').to.include('onExit');
+    expect(output+'').to.include('exit');
+  });
+
+  it('exits with error code if an on exit handler calls process.exit with code', function() {
+    var succeeded = false;
+    try {
+      var output = childProcess.execSync('node test-natural-exit-subprocess-error.js');
+      succeeded = true;
+    } catch(e) {
+      expect(e.output+'').to.include('onExit');
+      expect(e.output+'').to.include('exit');
+    }
+
+    if (succeeded) {
+      throw new Error('Unexpected zero exit status for process.exit(1)');
+    }
   });
 });
 

--- a/test.js
+++ b/test.js
@@ -154,6 +154,27 @@ describe('capture-exit', function() {
         exit.onExit(function () { });
       }).to.throw('Cannot install handler when exit is not captured.  Call `captureExit()` first');
     });
+
+    it('throws if an exit is already happening', function() {
+      return new Promise(function (resolve, reject) {
+        process.exit = function doNotReallyExit() { }
+        exit.captureExit();
+        function addHandler() {
+          try {
+            expect(function () {
+              exit.onExit(function () { console.log("it's too late!"); });
+            }).to.throw('Cannot install handler while `onExit` handlers are running.');
+          } catch(e) {
+            reject(e);
+          }
+
+          resolve();
+        }
+        exit.onExit(addHandler);
+
+        process.exit(2);
+      });
+    });
   });
 
   describe('.offExit', function() {

--- a/test.js
+++ b/test.js
@@ -7,12 +7,12 @@ var childProcess = require('child_process');
 
 describe('capture-exit', function() {
   beforeEach(function() {
-    exit.releaseExit();
     expect(process.exit, 'ensure we start in a correct state').to.equal(originalExit);
   });
 
   afterEach(function() {
     // always restore, in case we have bugs in our code while developing
+    exit._reset();
     process.exit = originalExit;
   });
 
@@ -33,11 +33,6 @@ describe('capture-exit', function() {
   });
 
   describe('.captureExit', function() {
-    afterEach(function() {
-      // always restore, in case we have bugs in our code while developing
-      exit.releaseExit();
-    });
-
     it('replace existing exit', function() {
       exit.captureExit();
       expect(process.exit, 'ensure we have replaced').to.not.equal(originalExit);
@@ -214,13 +209,30 @@ describe('natural exit', function() {
     expect(output+'').to.include('exit');
   });
 
-  it('exits with error code if an on exit handler calls process.exit with code', function() {
+  it("exits with error code if a process.on('exit') handler calls process.exit with code", function() {
     var succeeded = false;
     try {
       var output = childProcess.execSync('node test-natural-exit-subprocess-error.js');
       succeeded = true;
     } catch(e) {
       expect(e.output+'').to.include('onExit');
+      expect(e.output+'').to.include('exit');
+    }
+
+    if (succeeded) {
+      throw new Error('Unexpected zero exit status for process.exit(1)');
+    }
+  });
+
+
+  it("exits with error code if a captureExit.onExit handler calls process.exit with code", function() {
+    var succeeded = false;
+    try {
+      var output = childProcess.execSync('node test-natural-exit-subprocess-error-exit-from-captures-on-exit.js');
+      succeeded = true;
+    } catch(e) {
+      expect(e.output+'').to.include('onExit');
+      expect(e.output+'').to.include('onExit2');
       expect(e.output+'').to.include('exit');
     }
 


### PR DESCRIPTION
See https://github.com/ember-cli/ember-cli/issues/6486

- run handlers on a natural exit
- preserve exit code when calling `process.exit` from `process.on('exit')`
- maintain node's process.exit semantics

[Fix #6]