### PR TITLE
Restore error printing when catching errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ module.exports.captureExit = function() {
         if (own !== lastTime) {
           throw error;
         }
+        console.error(error);
         exit.call(process, 1);
       });
   };


### PR DESCRIPTION
When catching errors in `onExit` handlers, print the error, as we used to,
before exiting.