### PR TITLE
Add `.listenerCount` to allow consumers to confirm a listener was setup.

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,3 +136,7 @@ module.exports.offExit = function(cb) {
 module.exports.exit  = function() {
   exit.apply(process, arguments);
 };
+
+module.exports.listenerCount = function() {
+  return handlers.length;
+};

--- a/test.js
+++ b/test.js
@@ -288,6 +288,29 @@ describe('capture-exit', function() {
       });
     });
   });
+
+  describe('handlerCount', function() {
+    it('returns the current handler length', function() {
+      exit.captureExit();
+
+      expect(exit.listenerCount()).to.equal(0);
+
+      function foo() {}
+      function bar() {}
+
+      exit.onExit(foo);
+      expect(exit.listenerCount()).to.equal(1);
+
+      exit.onExit(bar);
+      expect(exit.listenerCount()).to.equal(2);
+
+      exit.offExit(foo);
+      expect(exit.listenerCount()).to.equal(1);
+
+      exit.offExit(bar);
+      expect(exit.listenerCount()).to.equal(0);
+    });
+  });
 });
 
 describe('natural exit', function() {


### PR DESCRIPTION
While testing a consumer of `capture-exit`, you might want to confirm that an `exit` handler was setup properly.

This change adds a `.listenerCount` method which returns the number of handlers that are present. This is similar conceptually to `EventEmitter.prototype.listenerCount` ([documented here](https://nodejs.org/api/events.html#events_emitter_listenercount_eventname)).