### PR TITLE
Prevent releaseExit while exiting.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,10 @@ process.on('beforeExit', function (code) {
 
 // This exists only for testing
 module.exports._reset = function () {
+  isExiting = false;
   module.exports.releaseExit();
   handlers = [];
   lastTime = undefined;
-  isExiting = false;
   firstExitCode = undefined;
 }
 
@@ -45,7 +45,11 @@ module.exports._reset = function () {
  *
  */
 module.exports.releaseExit = function() {
-  if (exit) {
+  // do not release exit after the first _flush has been called
+  // doing so will allow future `process.exit`'s  (during _flush)
+  // to kill the process without finishing any `captureExit.onExit`
+  // handlers
+  if (exit && !isExiting) {
     process.exit = exit;
     exit = null;
   }

--- a/test-release-exit-after-process-exit.js
+++ b/test-release-exit-after-process-exit.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// capture-exit-onExit.js
+var captureExit = require('./');
+
+var RSVP = require('rsvp');
+
+var interruptHandler;
+var promise = RSVP.Promise.resolve().
+    then(function() {
+      console.log('capturing exit');
+      captureExit.captureExit();
+      captureExit.onExit(interruptHandler);
+    }).
+    then(function() {
+      console.log('calling process.exit(1)');
+      process.exit(1);
+    }).
+    then(function() {
+      console.log('releasing exit');
+      captureExit.releaseExit();
+    }).
+    then(function() {
+      console.log('calling process.exit()');
+      process.exit();
+    });
+
+interruptHandler = function() {
+  console.log('interrupt handler running');
+  return promise;
+};

--- a/test.js
+++ b/test.js
@@ -32,6 +32,34 @@ describe('capture-exit', function() {
       exit.releaseExit();
       expect(process.exit, 'ensure we still remain in a correct state').to.equal(originalExit);
     });
+
+    it('does not release exit while exiting', function() {
+      exit.captureExit();
+      expect(process.exit, 'precond - ensure we have captured exit').to.not.equal(originalExit);
+
+      return exit._flush()
+        .then(function() {
+          exit.releaseExit();
+          expect(process.exit, 'ensure we have captured exit').to.not.equal(originalExit);
+        });
+    });
+
+    it('does not allow loosing prior exit codes while flushing', function() {
+      var succeeded = false;
+      try {
+        var output = childProcess.execSync('node test-release-exit-after-process-exit.js');
+        succeeded = true;
+      } catch(e) {
+        expect(e.output+'').to.include('capturing exit');
+        expect(e.output+'').to.include('calling process.exit(1)');
+        expect(e.output+'').to.include('releasing exit');
+        expect(e.output+'').to.include('calling process.exit()');
+      }
+
+      if (succeeded) {
+        throw new Error('Unexpected zero exit status for process.exit(1)');
+      }
+    });
   });
 
   describe('.captureExit', function() {


### PR DESCRIPTION
The following roughly emulates what ember-cli is doing (2.13 canary only):

```js
var captureExit = require('capture-exit');
var RSVP = require('rsvp');

var interruptHandler;
var promise = RSVP.Promise.resolve().
    then(function() {
      captureExit.captureExit();
      captureExit.onExit(interruptHandler);
    }).
    then(function() {
      // somewhere along the promise chain someone does:
      process.exit(1);
    }).
    then(function() {
      captureExit.releaseExit();
    }).
    then(function() {
      // later someone does:
      process.exit();
    });

interruptHandler = function() {
  return promise;
};
```

If we allow `.releaseExit` to run _during_ the `._flush` process, we can no longer ensure that the rest of the handlers are ran (if a `process.exit()` is ran after exit has been released).

See longer explaination / code safari in https://github.com/ember-cli/ember-cli/issues/6779#issuecomment-280940358.

---

This seems good to me, but I'd love feedback from @stefanpenner / @hjdivad / and others as there may be alternative conclusions to be made from the details in https://github.com/ember-cli/ember-cli/issues/6779.