### PR TITLE
make process injectable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-
+const EventEmitter = require('events');
 var RSVP = require('rsvp');
 
 var exit;
@@ -54,13 +54,18 @@ module.exports.releaseExit = function() {
 };
 
 var firstExitCode;
-module.exports.captureExit = function(p) {
-  _process = p || process;
-
+module.exports.captureExit = function(process) {
   if (exit) {
     // already captured, no need to do more work
     return;
   }
+
+  if (process instanceof EventEmitter === false) {
+    throw new Error('attempt to capture a bad process instance');
+  }
+
+  _process = process;
+
   exit = _process.exit;
 
   _process.exit = function(code) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('events');
 var RSVP = require('rsvp');
 

--- a/test-natural-exit-subprocess-error-exit-from-captures-on-exit.js
+++ b/test-natural-exit-subprocess-error-exit-from-captures-on-exit.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var capture = require('./');
-capture.captureExit();
+capture.captureExit(process);
 
 capture.onExit(function () {
   console.log('onExit');

--- a/test-natural-exit-subprocess-error.js
+++ b/test-natural-exit-subprocess-error.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var capture = require('./');
-capture.captureExit();
+capture.captureExit(process);
 
 capture.onExit(function () {
   console.log('onExit');

--- a/test-natural-exit-subprocess.js
+++ b/test-natural-exit-subprocess.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var capture = require('./');
-capture.captureExit();
+capture.captureExit(process);
 
 capture.onExit(function () {
   console.log('onExit');

--- a/test.js
+++ b/test.js
@@ -35,6 +35,16 @@ describe('capture-exit', function() {
   });
 
   describe('.captureExit', function() {
+    it('requires an EventEmitter instance', function() {
+        expect(function() {
+          exit.captureExit();
+        }).to.throw('attempt to capture a bad process instance');
+
+        expect(function() {
+          exit.captureExit({});
+        }).to.throw('attempt to capture a bad process instance');
+    });
+
     it('replace existing exit', function() {
       exit.captureExit(process);
       expect(process.exit, 'ensure we have replaced').to.not.equal(originalExit);

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ describe('capture-exit', function() {
     });
 
     it('restores the original exit', function() {
-      exit.captureExit();
+      exit.captureExit(process);
       expect(process.exit, 'ensure we have captured exit').to.not.equal(originalExit);
       exit.releaseExit();
       expect(process.exit, 'ensure we remain in a correct state').to.equal(originalExit);
@@ -36,13 +36,13 @@ describe('capture-exit', function() {
 
   describe('.captureExit', function() {
     it('replace existing exit', function() {
-      exit.captureExit();
+      exit.captureExit(process);
       expect(process.exit, 'ensure we have replaced').to.not.equal(originalExit);
     });
 
     it('replace existing but foreign exit', function() {
       var differentExit = process.exit = function() { };
-      exit.captureExit();
+      exit.captureExit(process);
       expect(process.exit, 'ensure we have replaced').to.not.equal(originalExit);
       expect(process.exit, 'ensure we have replaced').to.not.equal(differentExit);
       exit.releaseExit();
@@ -59,7 +59,7 @@ describe('capture-exit', function() {
         };
 
         var deferred;
-        exit.captureExit();
+        exit.captureExit(process);
         exit.onExit(function() {
           onExitWasCalled++;
           deferred = RSVP.defer();
@@ -100,7 +100,7 @@ describe('capture-exit', function() {
 
         };
 
-        exit.captureExit();
+        exit.captureExit(process);
         exit.onExit(function(code) {
           onExitWasCalled++;
           deferred = RSVP.defer();
@@ -151,7 +151,7 @@ describe('capture-exit', function() {
           expect(theError).to.equal(badThingsAreBad);
         };
 
-        exit.captureExit();
+        exit.captureExit(process);
         exit.onExit(function(code) {
           onExitWasCalled++;
           deferred = RSVP.defer();
@@ -190,7 +190,7 @@ describe('capture-exit', function() {
         };
 
         var deferred;
-        exit.captureExit();
+        exit.captureExit(process);
 
         exit.onExit(function() {
           onExitWasCalled++;
@@ -228,7 +228,7 @@ describe('capture-exit', function() {
         };
 
         var deferred;
-        exit.captureExit();
+        exit.captureExit(process);
 
         exit.onExit(function() {
           onExitWasCalled++;
@@ -295,7 +295,7 @@ describe('capture-exit', function() {
     });
 
     it('subscribes', function() {
-      exit.captureExit();
+      exit.captureExit(process);
       function foo() {
         didExit++;
       }
@@ -310,7 +310,7 @@ describe('capture-exit', function() {
     });
 
     it('throws an exit code of the first registered handler which rejects', function() {
-      exit.captureExit();
+      exit.captureExit(process);
 
       exit.onExit(handler({
         timeout: 10
@@ -340,7 +340,7 @@ describe('capture-exit', function() {
     });
 
     it('does not subscribe duplicates', function() {
-      exit.captureExit();
+      exit.captureExit(process);
       function foo() {
         didExit++;
       }
@@ -364,7 +364,7 @@ describe('capture-exit', function() {
     it('throws if an exit is already happening', function() {
       return new Promise(function (resolve, reject) {
         process.exit = function doNotReallyExit() { }
-        exit.captureExit();
+        exit.captureExit(process);
         function addHandler() {
           try {
             expect(function () {
@@ -385,7 +385,7 @@ describe('capture-exit', function() {
 
   describe('.offExit', function() {
     it('unsubscribes', function() {
-      exit.captureExit();
+      exit.captureExit(process);
 
       var didExit = 0;
       var didExitBar = 0;
@@ -406,7 +406,7 @@ describe('capture-exit', function() {
     });
 
     it('does not unsubscribe duplicates', function() {
-      exit.captureExit();
+      exit.captureExit(process);
 
       var didExit = 0;
       var didExitBar = 0;
@@ -430,7 +430,7 @@ describe('capture-exit', function() {
 
   describe('handlerCount', function() {
     it('returns the current handler length', function() {
-      exit.captureExit();
+      exit.captureExit(process);
 
       expect(exit.listenerCount()).to.equal(0);
 


### PR DESCRIPTION
this should simplify testing for the `capture-exit` consumers.
see: https://github.com/ro0gr/ember-cli/blob/42e9a039203c64a0ff2b784b34983eecdea00191/tests/unit/cli/cli-test.js#L94

I think it may be better to make `process` instance a required argument and stop using global one. 

- [x] tests to be updated
- [x] do something with [`process.on('beforeExit'`](https://github.com/ro0gr/capture-exit/blob/0cdf8a1f20226892eb333c49afc9d7db5ae0cd43/index.js#L10)